### PR TITLE
Add SmartPrices mod and camera lock

### DIFF
--- a/SMTQualityOfLife/Plugin.cs
+++ b/SMTQualityOfLife/Plugin.cs
@@ -16,15 +16,23 @@ namespace SMTQualityOfLife
         public ConfigEntry<bool> IsMainWindowEnabled;
         public ConfigEntry<bool> IsLowCountProductsWindowEnabled;
         public ConfigEntry<bool> IsNpcAdderWindowEnabled;
+        public ConfigEntry<bool> IsSmartPricesWindowEnabled;
         
         // === REFERENCES STUFF
         private MainManager _mainManager;
         private LowCountProducts _lowCountProducts;
         private NPCAdder _npcAdder;
+        private SmartPrices _smartPrices;
         
         // === PLUGIN STUFF
         private static readonly Harmony Harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
         
+        // === CAMERA LOCK
+        private bool _anyWindowOpen;
+        private Quaternion _savedCamLocalRot;
+        private Quaternion _savedCamParentLocalRot;
+        private bool _hasSavedCamState;
+
         // === KEYBOARD SHORTCUTS
         private static ConfigEntry<KeyboardShortcut> _keyboardShortcutEnableMainWindow;
         private static ConfigEntry<KeyboardShortcut> _keyboardShortcutDumpBlackboard;
@@ -33,6 +41,7 @@ namespace SMTQualityOfLife
         private static ConfigEntry<KeyboardShortcut> _keyboardShortcutDumpNpcManager;
         private static ConfigEntry<KeyboardShortcut> _keyboardShortcutDumpButtonsBar;
         private static ConfigEntry<KeyboardShortcut> _keyboardShortcutDumpProductListing;
+        private static ConfigEntry<KeyboardShortcut> _keyboardShortcutDumpPricing;
 
         private void Awake()
         {
@@ -58,10 +67,14 @@ namespace SMTQualityOfLife
             _keyboardShortcutDumpProductListing = Config.Bind("General",
                 "KeyboardShortcutDumpProductListing", new KeyboardShortcut(KeyCode.F12, new[] { KeyCode.LeftControl }),
                 (ConfigDescription.Empty));
+            _keyboardShortcutDumpPricing = Config.Bind("General",
+                "KeyboardShortcutDumpPricing", new KeyboardShortcut(KeyCode.F6, new[] { KeyCode.LeftControl }),
+                (ConfigDescription.Empty));
 
             _mainManager = new MainManager(Config, Logger);
             _lowCountProducts = new LowCountProducts(Config, _mainManager, new GUIUtilities());
             _npcAdder = new NPCAdder(Config, Logger, _mainManager, new GUIUtilities());
+            _smartPrices = new SmartPrices(Config, Logger, _mainManager, new GUIUtilities());
             
             IsMainWindowEnabled = Config.Bind(
                 "SMTQualityOfLife",
@@ -80,12 +93,19 @@ namespace SMTQualityOfLife
                 "NPC Adder",
                 false,
                 "Enable or disable the display of the NPCAdder mod window.");
+
+            IsSmartPricesWindowEnabled = Config.Bind(
+                "SMTQualityOfLife",
+                "Smart Prices",
+                false,
+                "Enable or disable the display of the SmartPrices mod window.");
             
             Instance = this;
 
             IsMainWindowEnabled.SettingChanged += OnMainWindowEnableChanged;
             IsLowCountProductsWindowEnabled.SettingChanged += OnLowCountProductWindowEnableChanged;
             IsNpcAdderWindowEnabled.SettingChanged += OnNpcAdderWindowEnableChanged;
+            IsSmartPricesWindowEnabled.SettingChanged += OnSmartPricesWindowEnableChanged;
             
             Harmony.PatchAll();
             
@@ -97,11 +117,12 @@ namespace SMTQualityOfLife
         {
             if (_keyboardShortcutEnableMainWindow.Value.IsDown())
             {
-                if (IsMainWindowEnabled.Value || IsLowCountProductsWindowEnabled.Value || IsNpcAdderWindowEnabled.Value)
+                if (IsMainWindowEnabled.Value || IsLowCountProductsWindowEnabled.Value || IsNpcAdderWindowEnabled.Value || IsSmartPricesWindowEnabled.Value)
                 {
                     IsMainWindowEnabled.Value = false;
                     IsLowCountProductsWindowEnabled.Value = false;
                     IsNpcAdderWindowEnabled.Value = false;
+                    IsSmartPricesWindowEnabled.Value = false;
                     Cursor.lockState = CursorLockMode.Locked;
                     Cursor.visible = false;
                 }
@@ -110,6 +131,7 @@ namespace SMTQualityOfLife
                     IsMainWindowEnabled.Value = true;
                     IsLowCountProductsWindowEnabled.Value = false;
                     IsNpcAdderWindowEnabled.Value = false;
+                    IsSmartPricesWindowEnabled.Value = false;
                     Cursor.lockState = CursorLockMode.None;
                     Cursor.visible = true;
                 }
@@ -186,6 +208,57 @@ namespace SMTQualityOfLife
                     Logger.LogError($"ProductListing debug failed: {ex}");
                 }
             }
+
+            if (_keyboardShortcutDumpPricing.Value.IsDown())
+            {
+                try
+                {
+                    DebugBlackboard.DumpPricingClasses();
+                }
+                catch (System.Exception ex)
+                {
+                    Logger.LogError($"Pricing discovery dump failed: {ex}");
+                }
+            }
+
+            // Track whether any mod window is open and manage camera freeze
+            _anyWindowOpen = IsMainWindowEnabled.Value || IsLowCountProductsWindowEnabled.Value ||
+                             IsNpcAdderWindowEnabled.Value || IsSmartPricesWindowEnabled.Value;
+
+            if (_anyWindowOpen)
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+
+                // Save camera state the first frame the GUI opens
+                if (!_hasSavedCamState)
+                {
+                    var cam = Camera.main;
+                    if (cam != null)
+                    {
+                        _savedCamLocalRot = cam.transform.localRotation;
+                        if (cam.transform.parent != null)
+                            _savedCamParentLocalRot = cam.transform.parent.localRotation;
+                        _hasSavedCamState = true;
+                    }
+                }
+            }
+            else
+            {
+                _hasSavedCamState = false;
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (!_anyWindowOpen || !_hasSavedCamState) return;
+
+            var cam = Camera.main;
+            if (cam == null) return;
+
+            cam.transform.localRotation = _savedCamLocalRot;
+            if (cam.transform.parent != null)
+                cam.transform.parent.localRotation = _savedCamParentLocalRot;
         }
 
         private void OnMainWindowEnableChanged(object sender, System.EventArgs e)
@@ -203,6 +276,11 @@ namespace SMTQualityOfLife
             _npcAdder.SetWindowVisibility(IsNpcAdderWindowEnabled.Value);
         }
 
+        private void OnSmartPricesWindowEnableChanged(object sender, System.EventArgs e)
+        {
+            _smartPrices.SetWindowVisibility(IsSmartPricesWindowEnabled.Value);
+        }
+
         private void OnGUI()
         {
             if (IsMainWindowEnabled.Value)
@@ -218,6 +296,11 @@ namespace SMTQualityOfLife
             if (IsNpcAdderWindowEnabled.Value)
             {
                 _npcAdder.DrawWindow();
+            }
+
+            if (IsSmartPricesWindowEnabled.Value)
+            {
+                _smartPrices.DrawWindow();
             }
         }
     }

--- a/SMTQualityOfLife/SMTQualityOfLife.csproj
+++ b/SMTQualityOfLife/SMTQualityOfLife.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>SMTQualityOfLife</AssemblyName>
     <Product>SMT QualityOfLife</Product>
-    <Version>1.1.3</Version>
+    <Version>1.2.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/SMTQualityOfLife/src/DebugBlackboard.cs
+++ b/SMTQualityOfLife/src/DebugBlackboard.cs
@@ -607,6 +607,136 @@ namespace SMTQualityOfLife
             EmitDump(sb);
         }
 
+        public static void DumpPricingClasses()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("[SMT QoL] ===== Pricing Classes Discovery Dump =====");
+            sb.AppendLine($"Time: {DateTime.Now:O}");
+
+            // Phase 1: Scan Assembly-CSharp for pricing-related types
+            Assembly gameAssembly = typeof(ManagerBlackboard).Assembly;
+            string[] keywords = { "price", "label", "gun", "tag", "margin", "cost",
+                                  "markup", "inflation", "profit" };
+
+            var matchingTypes = gameAssembly.GetTypes()
+                .Where(t =>
+                {
+                    string n = t.Name.ToLowerInvariant();
+                    return keywords.Any(k => n.Contains(k));
+                })
+                .OrderBy(t => t.Name)
+                .ToArray();
+
+            sb.AppendLine($"Matching types in {gameAssembly.GetName().Name}: {matchingTypes.Length}");
+            sb.AppendLine();
+
+            foreach (var type in matchingTypes)
+            {
+                sb.AppendLine($"=== TYPE: {type.FullName} ===");
+                sb.AppendLine($"  BaseType: {type.BaseType?.FullName}");
+                sb.AppendLine($"  IsClass: {type.IsClass}, IsEnum: {type.IsEnum}, IsValueType: {type.IsValueType}");
+
+                // Fields
+                var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Static |
+                                             BindingFlags.Public | BindingFlags.NonPublic);
+                if (fields.Length > 0)
+                {
+                    sb.AppendLine($"  FIELDS ({fields.Length}):");
+                    foreach (var f in fields)
+                    {
+                        string mod = f.IsStatic ? "static " : "";
+                        string access = f.IsPublic ? "public" : "private";
+                        sb.AppendLine($"    {access} {mod}{f.FieldType.Name} {f.Name}");
+                    }
+                }
+
+                // Properties
+                var props = type.GetProperties(BindingFlags.Instance | BindingFlags.Static |
+                                                BindingFlags.Public | BindingFlags.NonPublic);
+                if (props.Length > 0)
+                {
+                    sb.AppendLine($"  PROPERTIES ({props.Length}):");
+                    foreach (var p in props)
+                    {
+                        sb.AppendLine($"    {p.PropertyType.Name} {p.Name} [get={p.CanRead}, set={p.CanWrite}]");
+                    }
+                }
+
+                // Methods (declared only)
+                var methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Static |
+                                               BindingFlags.Public | BindingFlags.NonPublic |
+                                               BindingFlags.DeclaredOnly);
+                if (methods.Length > 0)
+                {
+                    sb.AppendLine($"  METHODS ({methods.Length}):");
+                    foreach (var m in methods)
+                    {
+                        string mod = m.IsStatic ? "static " : "";
+                        string parms = string.Join(", ",
+                            m.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}"));
+                        sb.AppendLine($"    {mod}{m.ReturnType.Name} {m.Name}({parms})");
+                    }
+                }
+
+                sb.AppendLine();
+            }
+
+            // Phase 2: Scan active scene GameObjects for live instances of matching types
+            sb.AppendLine("=== ACTIVE SCENE INSTANCES ===");
+            var allBehaviours = Object.FindObjectsOfType<MonoBehaviour>(true);
+            foreach (var type in matchingTypes)
+            {
+                if (!typeof(MonoBehaviour).IsAssignableFrom(type)) continue;
+                var instances = allBehaviours.Where(b => b != null && b.GetType() == type).ToArray();
+                if (instances.Length == 0) continue;
+
+                sb.AppendLine($"Found {instances.Length} instance(s) of {type.Name}:");
+                foreach (var inst in instances.Take(5))
+                {
+                    sb.AppendLine($"  GameObject: {GetFullPath(inst.transform)}");
+                    // Dump field values for the first instance to see runtime state
+                    if (inst == instances[0])
+                    {
+                        var instFields = type.GetFields(BindingFlags.Instance | BindingFlags.Public |
+                                                         BindingFlags.NonPublic);
+                        foreach (var f in instFields.Take(30))
+                        {
+                            var val = SafeGet(() => f.GetValue(inst));
+                            string valStr = SummarizeValue(f.FieldType, val);
+                            sb.AppendLine($"    {f.Name} = {valStr}");
+                        }
+                    }
+                }
+            }
+
+            // Phase 3: Scan ALL types for methods containing "price" in the method name
+            sb.AppendLine();
+            sb.AppendLine("=== METHODS CONTAINING 'price' IN ANY TYPE (first 50) ===");
+            int methodCount = 0;
+            foreach (var type in gameAssembly.GetTypes())
+            {
+                if (methodCount >= 50) break;
+                try
+                {
+                    var priceMethods = type.GetMethods(BindingFlags.Instance | BindingFlags.Static |
+                                                        BindingFlags.Public | BindingFlags.NonPublic |
+                                                        BindingFlags.DeclaredOnly)
+                        .Where(m => m.Name.IndexOf("price", StringComparison.OrdinalIgnoreCase) >= 0);
+                    foreach (var m in priceMethods)
+                    {
+                        if (methodCount >= 50) break;
+                        string parms = string.Join(", ",
+                            m.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}"));
+                        sb.AppendLine($"  {type.Name}.{m.Name}({parms}) -> {m.ReturnType.Name}");
+                        methodCount++;
+                    }
+                }
+                catch { /* skip types that throw on reflection */ }
+            }
+
+            EmitDump(sb);
+        }
+
         private static string SummarizeValue(Type type, object val)
         {
             if (val == null) return "<null>";

--- a/SMTQualityOfLife/src/MainManager.cs
+++ b/SMTQualityOfLife/src/MainManager.cs
@@ -21,7 +21,7 @@ namespace SMTQualityOfLife
         private readonly ConfigEntry<bool> _twentyCentsModEnabled;
         public readonly ConfigEntry<bool> NpcAdderEnabled;
         public readonly ConfigEntry<bool> LowProductCountEnabled;
-        private readonly ConfigEntry<bool> _smartPricesEnabled;
+        public readonly ConfigEntry<bool> SmartPricesEnabled;
         
         // === OTHER STUFF
         private readonly ManualLogSource _logger;
@@ -47,7 +47,7 @@ namespace SMTQualityOfLife
                 false,
                 "LowCountProducts Mod enabled");
             
-            _smartPricesEnabled = config.Bind(
+            SmartPricesEnabled = config.Bind(
                 "SmartPricesMod",
                 "SmartPrices Mod",
                 false,
@@ -56,7 +56,7 @@ namespace SMTQualityOfLife
             _tempTwentyCentsToggle = _twentyCentsModEnabled.Value;
             _tempNpcAdderToggle = NpcAdderEnabled.Value;
             _tempLowProductCountToggle = LowProductCountEnabled.Value;
-            _tempSmartPricesToggle = _smartPricesEnabled.Value;
+            _tempSmartPricesToggle = SmartPricesEnabled.Value;
         }
         
         public void SetWindowVisibility(bool visible)
@@ -95,23 +95,24 @@ namespace SMTQualityOfLife
             //     ref _tempTwentyCentsToggle,
             //     null);
             
-            _guiUtilities.DrawModSection(
-                "NPCAdder Mod",
-                "This mod allows you to add up to 15 NPC's employees to your store once you unlock all of the possible upgrades.",
-                ref _tempNpcAdderToggle,
-                OpenNpcAdderSettings);
-            
+            // NPCAdder Mod hidden — not implemented yet
+            // _guiUtilities.DrawModSection(
+            //     "NPCAdder Mod",
+            //     "This mod allows you to add up to 15 NPC's employees to your store once you unlock all of the possible upgrades.",
+            //     ref _tempNpcAdderToggle,
+            //     OpenNpcAdderSettings);
+
             _guiUtilities.DrawModSection(
                 "LowCountProducts Mod",
                 "This mod allows you to add all your low count products to the shopping cart at the manager blackboard by simply clicking a button.",
                 ref _tempLowProductCountToggle,
                 OpenLowCountProductsSettings);
             
-            // _guiUtilities.DrawModSection(
-            //     "SmartPrices Mod",
-            //     "This mod allows you to maximize your income by modifying the price set by the pricing machine to the highest price possible.",
-            //     ref _tempSmartPricesToggle,
-            //     OpenSmartPricesSettings);
+            _guiUtilities.DrawModSection(
+                "SmartPrices Mod",
+                "This mod allows you to maximize your income by modifying the price set by the pricing machine to the highest price possible.",
+                ref _tempSmartPricesToggle,
+                OpenSmartPricesSettings);
 
             GUILayout.EndScrollView();
             
@@ -135,9 +136,10 @@ namespace SMTQualityOfLife
                 _logger.LogInfo($"Low Count Product Enabled: {_tempLowProductCountToggle}");
             }
 
-            if (_smartPricesEnabled.Value != _tempSmartPricesToggle)
+            if (SmartPricesEnabled.Value != _tempSmartPricesToggle)
             {
-                _smartPricesEnabled.Value = _tempSmartPricesToggle;
+                SmartPricesEnabled.Value = _tempSmartPricesToggle;
+                SmartPrices.SmartPricesState = SmartPricesEnabled.Value;
                 _logger.LogInfo($"Smart Prices Enabled: {_tempSmartPricesToggle}");
             }
         }
@@ -158,7 +160,8 @@ namespace SMTQualityOfLife
 
         private void OpenSmartPricesSettings()
         {
-            _logger.LogInfo("Opening smart prices settings");
+            Plugin.Instance.IsMainWindowEnabled.Value = false;
+            Plugin.Instance.IsSmartPricesWindowEnabled.Value = true;
         }
     }
 }

--- a/SMTQualityOfLife/src/SmartPrices.cs
+++ b/SMTQualityOfLife/src/SmartPrices.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Globalization;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using HarmonyLib;
+using TMPro;
+using UnityEngine;
+
+namespace SMTQualityOfLife
+{
+    public class SmartPrices
+    {
+        // === GUI STUFF
+        private readonly GUIUtilities _guiUtilities;
+        private Rect _windowRect = new Rect(0, 0, Mathf.Min(Screen.width, 650), Screen.height < 560 ? Screen.height : Screen.height - 100);
+        private bool _showWindow;
+        private Vector2 _scrollPosition;
+
+        // === MOD STUFF
+        public static bool SmartPricesState;
+
+        // === CONFIG STUFF
+        public static ConfigEntry<float> PriceMarkupPercent;
+
+        // === CLASS REFERENCES
+        private readonly MainManager _manager;
+
+        // === OTHER STUFF
+        public static ManualLogSource Logger;
+
+        public SmartPrices(ConfigFile config, ManualLogSource logger, MainManager manager, GUIUtilities guiUtilities)
+        {
+            Logger = logger;
+            _guiUtilities = guiUtilities;
+            _manager = manager;
+
+            PriceMarkupPercent = config.Bind(
+                "SmartPricesMod",
+                "PriceMarkupPercent",
+                100f,
+                "Markup percentage above the base inflated price. Formula: basePrice * tierInflation * (1 + markup/100)");
+        }
+
+        public void SetWindowVisibility(bool visible)
+        {
+            if (visible && !_showWindow)
+            {
+                // Set initial window position when it becomes visible
+                _windowRect.x = (Screen.width - _windowRect.width) / 2;
+                _windowRect.y = (Screen.height - _windowRect.height) / 2 + 30;
+            }
+            _showWindow = visible;
+        }
+
+        public void DrawWindow()
+        {
+            if (_showWindow)
+            {
+                _windowRect = GUILayout.Window(2, _windowRect, DrawWindowContent, "SMTQualityOfLife - SmartPrices Mod");
+            }
+        }
+
+        private void DrawWindowContent(int windowID)
+        {
+            if (_guiUtilities.HeaderStyle == null)
+                _guiUtilities.InitializeStyles();
+
+            // Allow the window to be draggable
+            GUI.DragWindow(new Rect(0, 0, 10000, 20));
+
+            // 'Back' Button at the top left
+            if (GUI.Button(new Rect(10, 25, 60, 25), "< Back"))
+            {
+                OnBackButtonClicked();
+            }
+
+            GUILayout.Space(50);
+
+            // Check if mod is enabled
+            if (_manager.SmartPricesEnabled.Value)
+            {
+                // Start a scroll view in case content overflows
+                _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, GUILayout.Width(630), GUILayout.Height(420));
+
+                GUILayout.Label("SmartPrices Settings", _guiUtilities.HeaderStyle);
+                GUILayout.Space(5);
+                GUILayout.Label(
+                    "When you use the pricing gun on a product, the price will automatically be set " +
+                    "to the optimal value based on the markup percentage below.\n\n" +
+                    "Formula: base price x tier inflation x (1 + markup / 100)",
+                    _guiUtilities.DescriptionStyle);
+
+                GUILayout.Space(15);
+                _guiUtilities.DrawHorizontalLine();
+                GUILayout.Space(15);
+
+                // Markup percentage controls
+                GUILayout.Label("Price Markup", _guiUtilities.HeaderStyle);
+                GUILayout.Space(5);
+                GUILayout.Label(
+                    $"Current markup: {PriceMarkupPercent.Value:F0}%",
+                    _guiUtilities.LabelStyle);
+                GUILayout.Label(
+                    "Adjust the markup percentage above the base inflated price. " +
+                    "Higher values = more profit but risk angering customers.",
+                    _guiUtilities.DescriptionStyle);
+
+                GUILayout.Space(10);
+                GUILayout.BeginHorizontal();
+                if (GUILayout.Button("-5%", GUILayout.Width(70)))
+                    PriceMarkupPercent.Value = Mathf.Max(0f, PriceMarkupPercent.Value - 5f);
+                if (GUILayout.Button("-1%", GUILayout.Width(70)))
+                    PriceMarkupPercent.Value = Mathf.Max(0f, PriceMarkupPercent.Value - 1f);
+                if (GUILayout.Button("+1%", GUILayout.Width(70)))
+                    PriceMarkupPercent.Value += 1f;
+                if (GUILayout.Button("+5%", GUILayout.Width(70)))
+                    PriceMarkupPercent.Value += 5f;
+                GUILayout.EndHorizontal();
+
+                GUILayout.EndScrollView();
+            }
+            else
+            {
+                _guiUtilities.DrawModDisabledContent("SmartPrices");
+            }
+        }
+
+        private void OnBackButtonClicked()
+        {
+            Plugin.Instance.IsSmartPricesWindowEnabled.Value = false;
+            Plugin.Instance.IsMainWindowEnabled.Value = true;
+        }
+    }
+}
+
+namespace SMTQualityOfLife.Patches
+{
+    using SMTQualityOfLife;
+
+    [HarmonyPatch(typeof(PlayerNetwork))]
+    internal class SmartPricesPatch
+    {
+        [HarmonyPatch("Update")]
+        [HarmonyPostfix]
+        public static void Postfix(ref float ___pPrice, TextMeshProUGUI ___marketPriceTMP, ref TextMeshProUGUI ___yourPriceTMP)
+        {
+            if (!SmartPrices.SmartPricesState) return;
+            if (___marketPriceTMP == null) return;
+
+            string marketText = ___marketPriceTMP.text;
+            if (string.IsNullOrEmpty(marketText) || marketText.Length < 2) return;
+
+            // Strip leading "$" and parse the market price (already = basePricePerUnit * tierInflation)
+            if (!float.TryParse(
+                    marketText.Substring(1).Replace(',', '.'),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out float marketPrice))
+                return;
+
+            float markup = SmartPrices.PriceMarkupPercent.Value;
+            float smartPrice = marketPrice * (1f + markup / 100f);
+            smartPrice = Mathf.Floor(smartPrice * 20f) / 20f;
+
+            ___pPrice = smartPrice;
+            ___yourPriceTMP.text = "$" + smartPrice.ToString("F2", CultureInfo.InvariantCulture);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **SmartPrices mod**: automatically sets the pricing gun to a configurable markup over the market price (patches `PlayerNetwork.Update`, inspired by DoublePrices mod approach). Rounds prices down to nearest $0.05.
- **Camera freeze**: the in-game camera no longer rotates while any mod GUI window is open (save/restore rotation in `LateUpdate`).
- **Hide NPCAdder**: removed NPCAdder from the main GUI (not implemented yet, code preserved for future use).
- **Debug**: added Ctrl+F6 pricing classes discovery dump.
- **Version**: bumped to 1.2.0.

## Test plan
- [ ] Enable SmartPrices via Ctrl+H, use pricing gun — verify "Your Price" shows markup price rounded to $0.05
- [ ] Open GUI with Ctrl+H — verify camera does not rotate with mouse movement
- [ ] Verify NPCAdder no longer appears in the main mod list
- [ ] Close GUI with Ctrl+H — verify camera movement resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)